### PR TITLE
Update primary/accent colors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -23,13 +23,13 @@
   }
 
   .btn-primary {
-    @apply btn bg-primary text-white hover:bg-blue-600 
-           focus:ring-primary/50 active:bg-blue-700;
+    @apply btn bg-primary text-white hover:bg-blue-700
+           focus:ring-primary/50 active:bg-blue-800;
   }
 
   .btn-accent {
-    @apply btn bg-accent text-white hover:bg-orange-600 
-           focus:ring-accent/50 active:bg-orange-700;
+    @apply btn bg-accent text-white hover:bg-orange-800
+           focus:ring-accent/50 active:bg-orange-900;
   }
 
   .btn-outline {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,8 +7,8 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: '#3B82F6',    // blue-500
-        accent: '#F97316',     // orange-500
+        primary: '#2563EB',    // blue-600
+        accent: '#C2410C',     // orange-700
         'accent-alt': '#10B981', // emerald-500
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- use darker shades for primary and accent colors in Tailwind
- update button hover/active classes accordingly

## Testing
- `npm install`
- `npm run lint` *(fails: no-unused-vars and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_6840699358788320848b7c14fec27a19