### PR TITLE
Fix error variable handling in ChatInterface

### DIFF
--- a/src/components/Chatbot/ChatInterface.jsx
+++ b/src/components/Chatbot/ChatInterface.jsx
@@ -179,7 +179,8 @@ export default function ChatInterface() {
         relatedContent: responseData.related_content_slug,
         showHowToUseSuggestion: false
       };
-    } catch (catchError) {
+    } catch (error) {
+      console.error(error);
       return {
         content: langTrans.connectionError,
         relatedContent: null,


### PR DESCRIPTION
## Summary
- rename `catchError` variable to `error`
- log errors via `console.error`

## Testing
- `npm run lint` *(fails: 'useEffect' unused in other files)*

------
https://chatgpt.com/codex/tasks/task_e_684143f3d9688320a6a948fcd14b6e8a