### PR TITLE
Fix linter issues and tailwind plugin import

### DIFF
--- a/src/components/Chatbot/ChatInterface.jsx
+++ b/src/components/Chatbot/ChatInterface.jsx
@@ -179,7 +179,8 @@ export default function ChatInterface() {
         relatedContent: responseData.related_content_slug,
         showHowToUseSuggestion: false
       };
-    } catch (catchError) {
+    } catch (error) {
+      console.error(error);
       return {
         content: langTrans.connectionError,
         relatedContent: null,

--- a/src/pages/CsabRankPredictorPage.jsx
+++ b/src/pages/CsabRankPredictorPage.jsx
@@ -1,5 +1,5 @@
 // src/pages/CsabRankPredictorPage.jsx
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom'; 
 import { supabase } from '../lib/supabase';
 

--- a/src/pages/JosaaDocumentsPage.jsx
+++ b/src/pages/JosaaDocumentsPage.jsx
@@ -59,6 +59,7 @@ export default function JosaaDocumentsPage() {
         if (supabaseError) throw supabaseError;
         setDocuments(data || []);
       } catch (err) {
+        console.error(err);
         setError(uiText.errorLoading);
       } finally {
         setLoading(false);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import typography from '@tailwindcss/typography'
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -17,6 +19,6 @@ export default {
     },
   },
   plugins: [
-    require('@tailwindcss/typography'), 
+    typography,
   ],
 }


### PR DESCRIPTION
## Summary
- remove unused `useEffect` import
- log error to keep catch variable used
- update tailwind config to import typography plugin with `import`
- log caught error in ChatInterface to satisfy linter
- run eslint to ensure zero errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68413c6bd8bc8320a2d9a9259254b15e