### PR TITLE
Add year/round aware predictor helper

### DIFF
--- a/src/predictorConfig.js
+++ b/src/predictorConfig.js
@@ -1,0 +1,2 @@
+export const JOSAA_LATEST = { year: 2024, round: 6 };
+export const CSAB_LATEST = { year: 2024, round: 2 };


### PR DESCRIPTION
## Summary
- allow ChatInterface to expose `fetchCollegePredictions` helper
- default to latest JoSAA year/round via new `predictorConfig`

## Testing
- `npm run lint` *(fails: `ERR_MODULE_NOT_FOUND` earlier then other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68413c673f8883208445f2fd35f44cf5