### PR TITLE
Improve category parsing

### DIFF
--- a/src/components/Chatbot/ChatInterface.jsx
+++ b/src/components/Chatbot/ChatInterface.jsx
@@ -70,9 +70,45 @@ const uiTranslations = {
     howToUseReferralLinkText: "How to Use Guide",
     howToUseReferralSuffix: " chudandi.",
     predictorPopupText: "Mee college optionla gurinchi telusukovalani unda? Maa JoSAA College Predictor prayatninchandi!",
-    goToPredictorButton: "JoSAA College Predictor"
+  goToPredictorButton: "JoSAA College Predictor"
   }
 };
+
+export function parseCollegeQuery(query) {
+  const lower = query.toLowerCase();
+  const result = { category: null, rank: null };
+
+  const rankMatch = lower.match(/\b(\d{1,7})\b/);
+  if (rankMatch) result.rank = parseInt(rankMatch[1], 10);
+
+  const hasPwd = /\bpwd\b/.test(lower);
+  const mapping = {
+    open: 'OPEN',
+    general: 'OPEN',
+    gen: 'OPEN',
+    ur: 'OPEN',
+    unreserved: 'OPEN',
+    ews: 'EWS',
+    obc: 'OBC-NCL',
+    'obc-ncl': 'OBC-NCL',
+    sc: 'SC',
+    st: 'ST'
+  };
+
+  for (const [pattern, value] of Object.entries(mapping)) {
+    const regex = new RegExp(`\\b${pattern}\\b`, 'i');
+    if (regex.test(lower)) {
+      result.category = value;
+      break;
+    }
+  }
+
+  if (result.category && hasPwd) {
+    result.category += ' (PwD)';
+  }
+
+  return result;
+}
 
 export default function ChatInterface() {
   const [message, setMessage] = useState('');
@@ -179,7 +215,8 @@ export default function ChatInterface() {
         relatedContent: responseData.related_content_slug,
         showHowToUseSuggestion: false
       };
-    } catch (catchError) {
+    } catch (error) {
+      console.error('Error fetching response:', error);
       return {
         content: langTrans.connectionError,
         relatedContent: null,

--- a/src/pages/CsabRankPredictorPage.jsx
+++ b/src/pages/CsabRankPredictorPage.jsx
@@ -1,5 +1,5 @@
 // src/pages/CsabRankPredictorPage.jsx
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom'; 
 import { supabase } from '../lib/supabase';
 

--- a/src/pages/JosaaDocumentsPage.jsx
+++ b/src/pages/JosaaDocumentsPage.jsx
@@ -58,7 +58,8 @@ export default function JosaaDocumentsPage() {
 
         if (supabaseError) throw supabaseError;
         setDocuments(data || []);
-      } catch (err) {
+      } catch (error) {
+        console.error('Error fetching documents:', error);
         setError(uiText.errorLoading);
       } finally {
         setLoading(false);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import typography from '@tailwindcss/typography'
+
 export default {
   content: [
     "./index.html", //
@@ -17,6 +19,6 @@ export default {
     },
   },
   plugins: [
-    require('@tailwindcss/typography'), 
+    typography,
   ],
 }


### PR DESCRIPTION
## Summary
- add `parseCollegeQuery` helper in ChatInterface for college rank queries
- refine error handling in the chatbot response handler
- clean up unused imports and variables across pages
- fix Tailwind config plugin import

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68413c60956c83209063d4c0e191e0c8