### PR TITLE
Improve rank parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "tailwind:init": "tailwindcss init -p"
+    "tailwind:init": "tailwindcss init -p",
+    "test": "node tests/parseCollegeQuery.test.js"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",

--- a/src/components/Chatbot/ChatInterface.jsx
+++ b/src/components/Chatbot/ChatInterface.jsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { supabase } from '../../lib/supabase';
 import { useLanguage } from '../../contexts/LanguageContext';
+import { parseCollegeQuery } from '../../lib/parseCollegeQuery';
 
 const initialCategoriesBase = [
   { id: 'cat_josaa_docs', topicId: 'josaa_documents_general', labelKey: 'documentsLabel', queryKey: 'documentsQuery' },
@@ -13,32 +14,6 @@ const initialCategoriesBase = [
   { id: 'cat_colorblind', topicId: 'josaa_colorblind_general', labelKey: 'colorblindLabel', queryKey: 'colorblindQuery' },
 ];
 
-const categoryMap = {
-  obc: 'OBC-NCL',
-  'obc ncl': 'OBC-NCL',
-  sc: 'SC',
-  st: 'ST',
-  ews: 'EWS',
-  gen: 'OPEN',
-  general: 'OPEN',
-  open: 'OPEN'
-};
-
-function parseCollegeQuery(text) {
-  const lower = text.toLowerCase();
-  const rankMatch = lower.match(/\b(\d{3,})\b/);
-  const rank = rankMatch ? parseInt(rankMatch[1], 10) : null;
-  let category = null;
-  for (const key of Object.keys(categoryMap)) {
-    if (lower.includes(key)) { category = categoryMap[key]; break; }
-  }
-  const branchMatch = text.match(/\b(CSE|Computer Science|ECE|Electrical|Electronics|Mechanical|Civil|IT|Information Technology)\b/i);
-  const branch = branchMatch ? branchMatch[0] : null;
-  const instituteMatch = text.match(/(?:at|in|for)\s+([A-Za-z ]*(?:IIT|NIT|IIIT)[A-Za-z ]*)/i);
-  const institute = instituteMatch ? instituteMatch[1].trim() : null;
-  const isCollegeQuery = rank !== null || branch || institute || lower.includes('college');
-  return { rank, category, branch, institute, isCollegeQuery };
-}
 
 async function fetchCollegePredictions({ rank, category, branch, institute }) {
   try {
@@ -358,7 +333,8 @@ export default function ChatInterface() {
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
                   components={{
-                    a: ({node, ...props}) => (
+                    // eslint-disable-next-line no-unused-vars
+                    a: ({ node, ...props }) => (
                       <a
                         {...props}
                         target="_blank"

--- a/src/lib/parseCollegeQuery.js
+++ b/src/lib/parseCollegeQuery.js
@@ -1,0 +1,33 @@
+export const categoryMap = {
+  obc: 'OBC-NCL',
+  'obc ncl': 'OBC-NCL',
+  sc: 'SC',
+  st: 'ST',
+  ews: 'EWS',
+  gen: 'OPEN',
+  general: 'OPEN',
+  open: 'OPEN'
+};
+
+export function parseCollegeQuery(text) {
+  const lower = text.toLowerCase();
+  let match =
+    lower.match(/\brank(?:\s*is)?\s*#?(\d{1,4})\b/) ||
+    lower.match(/#?(\d{1,4})\s*rank\b/);
+  if (!match) {
+    match = lower.match(/\b(\d{3,})\b/);
+  }
+  const rankStr = match && (match[1] || match[2]);
+  const rank = rankStr ? parseInt(rankStr, 10) : null;
+
+  let category = null;
+  for (const key of Object.keys(categoryMap)) {
+    if (lower.includes(key)) { category = categoryMap[key]; break; }
+  }
+  const branchMatch = text.match(/\b(CSE|Computer Science|ECE|Electrical|Electronics|Mechanical|Civil|IT|Information Technology)\b/i);
+  const branch = branchMatch ? branchMatch[0] : null;
+  const instituteMatch = text.match(/(?:at|in|for)\s+([A-Za-z ]*(?:IIT|NIT|IIIT)[A-Za-z ]*)/i);
+  const institute = instituteMatch ? instituteMatch[1].trim() : null;
+  const isCollegeQuery = rank !== null || branch || institute || lower.includes('college');
+  return { rank, category, branch, institute, isCollegeQuery };
+}

--- a/tests/parseCollegeQuery.test.js
+++ b/tests/parseCollegeQuery.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { parseCollegeQuery } from '../src/lib/parseCollegeQuery.js';
+
+let result;
+
+result = parseCollegeQuery('My rank is 42 and I want CSE');
+assert.equal(result.rank, 42);
+
+result = parseCollegeQuery('rank 5, category gen');
+assert.equal(result.rank, 5);
+
+result = parseCollegeQuery('I have a 4231 rank in jee main');
+assert.equal(result.rank, 4231);
+
+result = parseCollegeQuery('I want 3 colleges');
+assert.equal(result.rank, null);
+
+console.log('All tests passed');
+


### PR DESCRIPTION
## Summary
- support short ranks in college query parsing
- move `parseCollegeQuery` to its own file and import where needed
- add basic unit tests for `parseCollegeQuery`
- expose a `test` npm script

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68414f1ffa048320846d502dc858af24