### PR TITLE
Extend category keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,19 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Accepted Category Keywords
+
+When asking the chatbot about college admissions or using the rank predictor,
+the following category keywords are understood (case-insensitive):
+
+- **OPEN**: `gen`, `general`, `open`
+- **OPEN (PwD)**: `gen pwd`, `general pwd`, `open pwd`, `gen-pwd`
+- **EWS**: `ews`
+- **EWS (PwD)**: `ews pwd`, `ews-pwd`
+- **OBC-NCL**: `obc`, `obc ncl`, `obc-ncl`
+- **OBC-NCL (PwD)**: `obc ncl pwd`, `obc-ncl pwd`, `obc-ncl-pwd`
+- **SC**: `sc`
+- **SC (PwD)**: `sc pwd`, `sc-pwd`
+- **ST**: `st`
+- **ST (PwD)**: `st pwd`, `st-pwd`

--- a/src/lib/parseCollegeQuery.js
+++ b/src/lib/parseCollegeQuery.js
@@ -1,6 +1,29 @@
 export const categoryMap = {
-  obc: 'OBC-NCL',
+  // PwD variations first so they match before the non-PwD keywords
+  'gen pwd': 'OPEN (PwD)',
+  'gen-pwd': 'OPEN (PwD)',
+  'general pwd': 'OPEN (PwD)',
+  'general-pwd': 'OPEN (PwD)',
+  'open pwd': 'OPEN (PwD)',
+  'open-pwd': 'OPEN (PwD)',
+
+  'ews pwd': 'EWS (PwD)',
+  'ews-pwd': 'EWS (PwD)',
+
+  'obc ncl pwd': 'OBC-NCL (PwD)',
+  'obc-ncl pwd': 'OBC-NCL (PwD)',
+  'obc-ncl-pwd': 'OBC-NCL (PwD)',
+
+  'sc pwd': 'SC (PwD)',
+  'sc-pwd': 'SC (PwD)',
+
+  'st pwd': 'ST (PwD)',
+  'st-pwd': 'ST (PwD)',
+
+  // Standard non-PwD keywords
   'obc ncl': 'OBC-NCL',
+  'obc-ncl': 'OBC-NCL',
+  obc: 'OBC-NCL',
   sc: 'SC',
   st: 'ST',
   ews: 'EWS',
@@ -21,8 +44,8 @@ export function parseCollegeQuery(text) {
   const rank = rankStr ? parseInt(rankStr, 10) : null;
 
   let category = null;
-  for (const key of Object.keys(categoryMap)) {
-    if (lower.includes(key)) { category = categoryMap[key]; break; }
+  for (const [key, value] of Object.entries(categoryMap)) {
+    if (lower.includes(key.toLowerCase())) { category = value; break; }
   }
   const branchMatch = text.match(/\b(CSE|Computer Science|ECE|Electrical|Electronics|Mechanical|Civil|IT|Information Technology)\b/i);
   const branch = branchMatch ? branchMatch[0] : null;

--- a/tests/parseCollegeQuery.test.js
+++ b/tests/parseCollegeQuery.test.js
@@ -15,5 +15,14 @@ assert.equal(result.rank, 4231);
 result = parseCollegeQuery('I want 3 colleges');
 assert.equal(result.rank, null);
 
+result = parseCollegeQuery('rank 123 obc-ncl pwd');
+assert.equal(result.category, 'OBC-NCL (PwD)');
+
+result = parseCollegeQuery('rank 99 gen pwd');
+assert.equal(result.category, 'OPEN (PwD)');
+
+result = parseCollegeQuery('rank 100 ews-pwd');
+assert.equal(result.category, 'EWS (PwD)');
+
 console.log('All tests passed');
 


### PR DESCRIPTION
## Summary
- handle additional PwD/hyphenated forms in `parseCollegeQuery`
- document accepted category keywords
- test category parser with new variations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841539210c083208b36a4728dc91a78