### PR TITLE
Fix link to rank predictor from chatbot

### DIFF
--- a/src/components/Chatbot/ChatInterface.jsx
+++ b/src/components/Chatbot/ChatInterface.jsx
@@ -247,7 +247,7 @@ export default function ChatInterface() {
         });
         if (colleges.length > 0) {
           const lines = colleges.map(c => `\ud83c\udf93 ${c.institute_name} \u2013 ${c.branch_name}`).join('\n');
-          const link = `https://guruvela.in/college-predictor?rank=${parsed.rank}&cat=${encodeURIComponent(parsed.category)}`;
+          const link = `/rank-predictor?rank=${parsed.rank}&cat=${encodeURIComponent(parsed.category)}`;
           response = {
             content: `${currentUiText.collegeSuggestionPrefix}\n${lines}\n[${currentUiText.viewFullListText}](${link})`,
             relatedContent: null,


### PR DESCRIPTION
## Summary
- fix link in chatbot quick reply to use `/rank-predictor`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68414e0674588320a709529851b21e93