### PR TITLE
Enhance predictor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ the following category keywords are understood (case-insensitive):
 - **SC (PwD)**: `sc pwd`, `sc-pwd`
 - **ST**: `st`
 - **ST (PwD)**: `st pwd`, `st-pwd`
+
+## Exam Type Keywords
+
+When specifying the exam type in chatbot queries, the following keywords are understood:
+
+- **JEE Main**: `jee main`, `jee mains`, `main exam`
+- **JEE Advanced**: `jee advanced`, `jee advance`, `advanced`

--- a/src/components/Chatbot/ChatInterface.jsx
+++ b/src/components/Chatbot/ChatInterface.jsx
@@ -17,7 +17,7 @@ const initialCategoriesBase = [
 
 
 async function fetchCollegePredictions(
-  { rank, category, branch, institute },
+  { rank, category, branch, institute, examType },
   { year = JOSAA_PREDICTION_YEAR, round = JOSAA_PREDICTION_ROUND } = {}
 ) {
   try {
@@ -26,7 +26,7 @@ async function fetchCollegePredictions(
       .select('institute_name, branch_name, closing_rank')
       .eq('year', year)
       .eq('round_no', round)
-      .eq('exam_type', 'JEE Main')
+      .eq('exam_type', examType || 'JEE Main')
       .eq('seat_type', category)
       .gte('closing_rank', rank);
 
@@ -64,7 +64,7 @@ const uiTranslations = {
     goToPredictorButton: "JoSAA College Predictor",
     collegeSuggestionPrefix: "Here are the top 3 colleges you might get based on your rank and category:",
     viewFullListText: "View Full List on Guruvela",
-    clarifyMissingInfo: "Can you tell me your JEE rank and category (General, OBC, SC, etc.)?"
+    clarifyMissingInfo: "Can you tell me your JEE rank, category (General, OBC, SC, etc.) and exam type (Main or Advanced)?"
   },
   'hi-en': {
     greeting: "Namaste! Main Guruvela ka assistant hoon. JoSAA/CSAB counselling mein aapki kya help kar sakta hoon?",
@@ -87,7 +87,7 @@ const uiTranslations = {
     goToPredictorButton: "JoSAA College Predictor",
     collegeSuggestionPrefix: "Yeh hain top 3 colleges jo aapke rank aur category ke hisaab se mil sakte hain:",
     viewFullListText: "Puri list Guruvela par dekhein",
-    clarifyMissingInfo: "Kya aap apna JEE rank aur category bata sakte hain (General, OBC, SC, etc.)?"
+    clarifyMissingInfo: "Kya aap apna JEE rank, category (General, OBC, SC, etc.) aur exam type bata sakte hain?"
   },
   'te-en': {
     greeting: "Namaste! Nenu Guruvela assistant. JoSAA/CSAB counselling lo ela help cheyagalanu?",
@@ -110,7 +110,7 @@ const uiTranslations = {
     goToPredictorButton: "JoSAA College Predictor",
     collegeSuggestionPrefix: "Mee rank mariyu category ni base cheskoni meeku dorakachu anukune top 3 colleges:",
     viewFullListText: "Full list Guruvela lo chudandi",
-    clarifyMissingInfo: "Mee JEE rank mariyu category (General, OBC, SC, etc.) cheppagalara?"
+    clarifyMissingInfo: "Mee JEE rank, category (General, OBC, SC, etc.) mariyu exam type cheppagalara?"
   }
 };
 
@@ -238,7 +238,7 @@ export default function ChatInterface() {
     const parsed = parseCollegeQuery(currentMessageText);
     let response;
     if (parsed.isCollegeQuery) {
-      if (!parsed.rank || !parsed.category) {
+      if (!parsed.rank || !parsed.category || !parsed.examType) {
         response = { content: currentUiText.clarifyMissingInfo, relatedContent: null, showHowToUseSuggestion: false };
       } else {
         const colleges = await fetchCollegePredictions(parsed, {
@@ -247,7 +247,7 @@ export default function ChatInterface() {
         });
         if (colleges.length > 0) {
           const lines = colleges.map(c => `\ud83c\udf93 ${c.institute_name} \u2013 ${c.branch_name}`).join('\n');
-          const link = `https://guruvela.in/college-predictor?rank=${parsed.rank}&cat=${encodeURIComponent(parsed.category)}`;
+          const link = `/rank-predictor?rank=${parsed.rank}&cat=${encodeURIComponent(parsed.category)}&exam=${encodeURIComponent(parsed.examType)}`;
           response = {
             content: `${currentUiText.collegeSuggestionPrefix}\n${lines}\n[${currentUiText.viewFullListText}](${link})`,
             relatedContent: null,

--- a/src/lib/parseCollegeQuery.js
+++ b/src/lib/parseCollegeQuery.js
@@ -32,6 +32,15 @@ export const categoryMap = {
   open: 'OPEN'
 };
 
+export const examTypeMap = {
+  'jee main': 'JEE Main',
+  'jee mains': 'JEE Main',
+  'main exam': 'JEE Main',
+  'jee advanced': 'JEE Advanced',
+  'jee advance': 'JEE Advanced',
+  advanced: 'JEE Advanced'
+};
+
 export function parseCollegeQuery(text) {
   const lower = text.toLowerCase();
   let match =
@@ -51,6 +60,10 @@ export function parseCollegeQuery(text) {
   const branch = branchMatch ? branchMatch[0] : null;
   const instituteMatch = text.match(/(?:at|in|for)\s+([A-Za-z ]*(?:IIT|NIT|IIIT)[A-Za-z ]*)/i);
   const institute = instituteMatch ? instituteMatch[1].trim() : null;
+  let examType = null;
+  for (const [key, value] of Object.entries(examTypeMap)) {
+    if (lower.includes(key.toLowerCase())) { examType = value; break; }
+  }
   const isCollegeQuery = rank !== null || branch || institute || lower.includes('college');
-  return { rank, category, branch, institute, isCollegeQuery };
+  return { rank, category, branch, institute, examType, isCollegeQuery };
 }

--- a/src/pages/RankPredictorPage.jsx
+++ b/src/pages/RankPredictorPage.jsx
@@ -1,6 +1,6 @@
 // src/pages/RankPredictorPage.jsx
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { fetchCollegePredictions } from '../lib/fetchCollegePredictions';
 import {
   JOSAA_PREDICTION_YEAR,
@@ -20,6 +20,8 @@ export default function RankPredictorPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [searched, setSearched] = useState(false);
+  const location = useLocation();
+  const [autoTrigger, setAutoTrigger] = useState(false);
 
   const { language } = useLanguage();
 
@@ -49,6 +51,18 @@ export default function RankPredictorPage() {
   };
   const uiText = pageTranslations[language] || pageTranslations.en;
 
+  // Parse query params for pre-filled values
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const r = params.get('rank');
+    const c = params.get('cat');
+    const exam = params.get('exam');
+    if (r) setRank(r);
+    if (c) setCategory(c);
+    if (exam) setExamType(exam);
+    if (r && c && exam) setAutoTrigger(true);
+  }, [location.search]);
+
   useEffect(() => {
     if (examType === 'JEE Advanced') {
       setQuota('AI');
@@ -67,6 +81,13 @@ export default function RankPredictorPage() {
       setQuota('AI');
     }
   }, []);
+
+  useEffect(() => {
+    if (autoTrigger) {
+      handleSubmit(null);
+      setAutoTrigger(false);
+    }
+  }, [autoTrigger]);
 
 
   const handleSubmit = async (e) => {

--- a/tests/parseCollegeQuery.test.js
+++ b/tests/parseCollegeQuery.test.js
@@ -11,6 +11,7 @@ assert.equal(result.rank, 5);
 
 result = parseCollegeQuery('I have a 4231 rank in jee main');
 assert.equal(result.rank, 4231);
+assert.equal(result.examType, 'JEE Main');
 
 result = parseCollegeQuery('I want 3 colleges');
 assert.equal(result.rank, null);
@@ -23,6 +24,12 @@ assert.equal(result.category, 'OPEN (PwD)');
 
 result = parseCollegeQuery('rank 100 ews-pwd');
 assert.equal(result.category, 'EWS (PwD)');
+
+result = parseCollegeQuery('my jee advanced rank is 4321 sc');
+assert.equal(result.examType, 'JEE Advanced');
+
+result = parseCollegeQuery('rank 50 obc');
+assert.equal(result.examType, null);
 
 console.log('All tests passed');
 


### PR DESCRIPTION
## Summary
- parse exam type in `parseCollegeQuery`
- ask for exam type in chatbot clarifications
- pass exam type to Supabase query
- deep link to predictor page with rank, category and exam type
- auto fill predictor page from URL params
- document exam keywords
- test parseCollegeQuery for new exam parsing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68414e0674588320a709529851b21e93