### PR TITLE
Improve college predictor link

### DIFF
--- a/src/components/Chatbot/ChatInterface.jsx
+++ b/src/components/Chatbot/ChatInterface.jsx
@@ -241,13 +241,23 @@ export default function ChatInterface() {
       if (!parsed.rank || !parsed.category) {
         response = { content: currentUiText.clarifyMissingInfo, relatedContent: null, showHowToUseSuggestion: false };
       } else {
-        const colleges = await fetchCollegePredictions(parsed, {
-          year: JOSAA_PREDICTION_YEAR,
-          round: JOSAA_PREDICTION_ROUND,
-        });
+        const colleges = await fetchCollegePredictions(
+          {
+            rank: parsed.rank,
+            examType: parsed.examType || 'JEE Main',
+            category: parsed.category,
+            quota: '',
+            gender: 'Gender-Neutral',
+            isPreparatoryRank: false,
+          },
+          {
+            year: JOSAA_PREDICTION_YEAR,
+            round: JOSAA_PREDICTION_ROUND,
+          }
+        );
         if (colleges.length > 0) {
           const lines = colleges.map(c => `\ud83c\udf93 ${c.institute_name} \u2013 ${c.branch_name}`).join('\n');
-          const link = `/rank-predictor?rank=${parsed.rank}&cat=${encodeURIComponent(parsed.category)}`;
+          const link = `/rank-predictor?rank=${parsed.rank}&cat=${encodeURIComponent(parsed.category)}&examType=${encodeURIComponent(parsed.examType || 'JEE Main')}`;
           response = {
             content: `${currentUiText.collegeSuggestionPrefix}\n${lines}\n[${currentUiText.viewFullListText}](${link})`,
             relatedContent: null,

--- a/src/lib/parseCollegeQuery.js
+++ b/src/lib/parseCollegeQuery.js
@@ -51,6 +51,13 @@ export function parseCollegeQuery(text) {
   const branch = branchMatch ? branchMatch[0] : null;
   const instituteMatch = text.match(/(?:at|in|for)\s+([A-Za-z ]*(?:IIT|NIT|IIIT)[A-Za-z ]*)/i);
   const institute = instituteMatch ? instituteMatch[1].trim() : null;
+
+  let examType = null;
+  if (/\bjee\s*advanced\b/.test(lower) || /\bjee[-\s]?adv\b/.test(lower)) {
+    examType = 'JEE Advanced';
+  } else if (/\bjee\s*mains?\b/.test(lower) || /\bjee[-\s]?main\b/.test(lower)) {
+    examType = 'JEE Main';
+  }
   const isCollegeQuery = rank !== null || branch || institute || lower.includes('college');
-  return { rank, category, branch, institute, isCollegeQuery };
+  return { rank, category, branch, institute, examType, isCollegeQuery };
 }

--- a/src/pages/RankPredictorPage.jsx
+++ b/src/pages/RankPredictorPage.jsx
@@ -1,6 +1,6 @@
 // src/pages/RankPredictorPage.jsx
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { fetchCollegePredictions } from '../lib/fetchCollegePredictions';
 import {
   JOSAA_PREDICTION_YEAR,
@@ -21,7 +21,11 @@ export default function RankPredictorPage() {
   const [error, setError] = useState(null);
   const [searched, setSearched] = useState(false);
 
+  const [autoSearch, setAutoSearch] = useState(false);
+
   const { language } = useLanguage();
+
+  const [searchParams] = useSearchParams();
 
   // Corrected link
   const preparatoryGuideLink = "/pages/iit-prep-course-guide";
@@ -48,6 +52,23 @@ export default function RankPredictorPage() {
     }
   };
   const uiText = pageTranslations[language] || pageTranslations.en;
+
+  useEffect(() => {
+    const rankParam = searchParams.get('rank');
+    const catParam = searchParams.get('cat');
+    const examParam = searchParams.get('examType');
+    if (rankParam) setRank(rankParam);
+    if (catParam) setCategory(catParam);
+    if (examParam) setExamType(examParam);
+    if (rankParam && catParam && examParam) setAutoSearch(true);
+  }, []); // run once on mount
+
+  useEffect(() => {
+    if (autoSearch && rank && category && examType) {
+      handleSubmit();
+      setAutoSearch(false);
+    }
+  }, [autoSearch, rank, category, examType]);
 
   useEffect(() => {
     if (examType === 'JEE Advanced') {

--- a/tests/parseCollegeQuery.test.js
+++ b/tests/parseCollegeQuery.test.js
@@ -11,6 +11,7 @@ assert.equal(result.rank, 5);
 
 result = parseCollegeQuery('I have a 4231 rank in jee main');
 assert.equal(result.rank, 4231);
+assert.equal(result.examType, 'JEE Main');
 
 result = parseCollegeQuery('I want 3 colleges');
 assert.equal(result.rank, null);
@@ -23,6 +24,9 @@ assert.equal(result.category, 'OPEN (PwD)');
 
 result = parseCollegeQuery('rank 100 ews-pwd');
 assert.equal(result.category, 'EWS (PwD)');
+
+result = parseCollegeQuery('rank 50 in jee advanced');
+assert.equal(result.examType, 'JEE Advanced');
 
 console.log('All tests passed');
 


### PR DESCRIPTION
## Summary
- parse exam type from user queries
- pre-fill rank predictor link with rank, category & exam type
- auto-populate Rank Predictor fields from query parameters and search automatically
- update tests for new parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684163346f1483208775d095120b37b3