### PR TITLE
Add state-aware college prediction

### DIFF
--- a/src/lib/fetchCollegePredictions.js
+++ b/src/lib/fetchCollegePredictions.js
@@ -6,7 +6,8 @@ export async function fetchCollegePredictions({
   category,
   quota,
   gender,
-  isPreparatoryRank
+  isPreparatoryRank,
+  state
 }, { year = new Date().getFullYear(), round = 6 } = {}) {
   const userRankInt = parseInt(rank);
   if (isNaN(userRankInt) || userRankInt <= 0) {
@@ -21,7 +22,11 @@ export async function fetchCollegePredictions({
     .eq('exam_type', examType)
     .eq('seat_type', category);
 
-  if (quota) {
+  if (state && quota === 'HS') {
+    query = query.eq('state', state).eq('quota', 'HS');
+  } else if (state && quota === 'OS') {
+    query = query.neq('state', state).eq('quota', 'OS');
+  } else if (quota) {
     query = query.eq('quota', quota);
   }
 

--- a/src/lib/parseCollegeQuery.js
+++ b/src/lib/parseCollegeQuery.js
@@ -32,6 +32,48 @@ export const categoryMap = {
   open: 'OPEN'
 };
 
+export const stateKeywords = {
+  'andhra pradesh': 'Andhra Pradesh',
+  'arunachal pradesh': 'Arunachal Pradesh',
+  assam: 'Assam',
+  bihar: 'Bihar',
+  chhattisgarh: 'Chhattisgarh',
+  goa: 'Goa',
+  gujarat: 'Gujarat',
+  haryana: 'Haryana',
+  'himachal pradesh': 'Himachal Pradesh',
+  jammu: 'Jammu and Kashmir',
+  kashmir: 'Jammu and Kashmir',
+  jharkhand: 'Jharkhand',
+  karnataka: 'Karnataka',
+  kerala: 'Kerala',
+  'madhya pradesh': 'Madhya Pradesh',
+  maharashtra: 'Maharashtra',
+  manipur: 'Manipur',
+  meghalaya: 'Meghalaya',
+  mizoram: 'Mizoram',
+  nagaland: 'Nagaland',
+  odisha: 'Odisha',
+  orissa: 'Odisha',
+  punjab: 'Punjab',
+  rajasthan: 'Rajasthan',
+  sikkim: 'Sikkim',
+  'tamil nadu': 'Tamil Nadu',
+  telangana: 'Telangana',
+  tripura: 'Tripura',
+  'uttar pradesh': 'Uttar Pradesh',
+  uttarakhand: 'Uttarakhand',
+  'west bengal': 'West Bengal',
+  delhi: 'Delhi',
+  ladakh: 'Ladakh',
+  chandigarh: 'Chandigarh',
+  'andaman and nicobar': 'Andaman and Nicobar Islands',
+  'dadra and nagar haveli': 'Dadra and Nagar Haveli and Daman and Diu',
+  'daman and diu': 'Dadra and Nagar Haveli and Daman and Diu',
+  puducherry: 'Puducherry',
+  lakshadweep: 'Lakshadweep'
+};
+
 export function parseCollegeQuery(text) {
   const lower = text.toLowerCase();
   let match =
@@ -52,6 +94,12 @@ export function parseCollegeQuery(text) {
   const instituteMatch = text.match(/(?:at|in|for)\s+([A-Za-z ]*(?:IIT|NIT|IIIT)[A-Za-z ]*)/i);
   const institute = instituteMatch ? instituteMatch[1].trim() : null;
 
+  let state = null;
+  for (const [key, value] of Object.entries(stateKeywords)) {
+    const regex = new RegExp(`\\b${key}\\b`, 'i');
+    if (regex.test(lower)) { state = value; break; }
+  }
+
   let examType = null;
   if (/\bjee\s*advanced\b/.test(lower) || /\bjee[-\s]?adv\b/.test(lower)) {
     examType = 'JEE Advanced';
@@ -59,5 +107,5 @@ export function parseCollegeQuery(text) {
     examType = 'JEE Main';
   }
   const isCollegeQuery = rank !== null || branch || institute || lower.includes('college');
-  return { rank, category, branch, institute, examType, isCollegeQuery };
+  return { rank, category, branch, institute, state, examType, isCollegeQuery };
 }

--- a/src/pages/RankPredictorPage.jsx
+++ b/src/pages/RankPredictorPage.jsx
@@ -15,6 +15,7 @@ export default function RankPredictorPage() {
   const [quota, setQuota] = useState('');
   const [gender, setGender] = useState('Gender-Neutral');
   const [isPreparatoryRank, setIsPreparatoryRank] = useState(false);
+  const [state, setState] = useState('');
 
   const [results, setResults] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -57,18 +58,22 @@ export default function RankPredictorPage() {
     const rankParam = searchParams.get('rank');
     const catParam = searchParams.get('cat');
     const examParam = searchParams.get('examType');
+    const stateParam = searchParams.get('state');
+    const quotaParam = searchParams.get('quota');
     if (rankParam) setRank(rankParam);
     if (catParam) setCategory(catParam);
     if (examParam) setExamType(examParam);
-    if (rankParam && catParam && examParam) setAutoSearch(true);
+    if (stateParam) setState(stateParam);
+    if (quotaParam) setQuota(quotaParam);
+    if (rankParam && catParam && examParam && stateParam && quotaParam) setAutoSearch(true);
   }, []); // run once on mount
 
   useEffect(() => {
-    if (autoSearch && rank && category && examType) {
+    if (autoSearch && rank && category && examType && state && quota) {
       handleSubmit();
       setAutoSearch(false);
     }
-  }, [autoSearch, rank, category, examType]);
+  }, [autoSearch, rank, category, examType, state, quota]);
 
   useEffect(() => {
     if (examType === 'JEE Advanced') {
@@ -111,6 +116,7 @@ export default function RankPredictorPage() {
           quota,
           gender,
           isPreparatoryRank,
+          state,
         },
         { year: JOSAA_PREDICTION_YEAR, round: JOSAA_PREDICTION_ROUND }
       );

--- a/tests/parseCollegeQuery.test.js
+++ b/tests/parseCollegeQuery.test.js
@@ -28,5 +28,11 @@ assert.equal(result.category, 'EWS (PwD)');
 result = parseCollegeQuery('rank 50 in jee advanced');
 assert.equal(result.examType, 'JEE Advanced');
 
+result = parseCollegeQuery("I'm from Maharashtra with rank 1500");
+assert.equal(result.state, 'Maharashtra');
+
+result = parseCollegeQuery('my state is karnataka');
+assert.equal(result.state, 'Karnataka');
+
 console.log('All tests passed');
 


### PR DESCRIPTION
## Summary
- detect states in `parseCollegeQuery`
- support state filtering in `fetchCollegePredictions`
- store user's state in the chat interface and request it if missing
- include quota and state in links to the rank predictor
- allow `RankPredictorPage` to read `state` and auto-search
- test new state parsing

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684167867e688320a8f72f58975b0886