### PR TITLE
Fix exam type detection and filter architecture branches

### DIFF
--- a/src/lib/fetchCollegePredictions.js
+++ b/src/lib/fetchCollegePredictions.js
@@ -43,5 +43,6 @@ export async function fetchCollegePredictions({
     throw error;
   }
 
-  return data || [];
+  const filtered = (data || []).filter(item => !/architecture/i.test(item.branch_name));
+  return filtered;
 }

--- a/src/lib/parseCollegeQuery.js
+++ b/src/lib/parseCollegeQuery.js
@@ -101,7 +101,7 @@ export function parseCollegeQuery(text) {
   }
 
   let examType = null;
-  if (/\bjee\s*advanced\b/.test(lower) || /\bjee[-\s]?adv\b/.test(lower)) {
+  if (/\bjee\s*advanced\b/.test(lower) || /\bjee[-\s]?adv\b/.test(lower) || /\bjeeadv(?:ance|anced)?\b/.test(lower)) {
     examType = 'JEE Advanced';
   } else if (/\bjee\s*mains?\b/.test(lower) || /\bjee[-\s]?main\b/.test(lower)) {
     examType = 'JEE Main';

--- a/tests/parseCollegeQuery.test.js
+++ b/tests/parseCollegeQuery.test.js
@@ -28,6 +28,9 @@ assert.equal(result.category, 'EWS (PwD)');
 result = parseCollegeQuery('rank 50 in jee advanced');
 assert.equal(result.examType, 'JEE Advanced');
 
+result = parseCollegeQuery('rank 99 in JeeAdvance');
+assert.equal(result.examType, 'JEE Advanced');
+
 result = parseCollegeQuery("I'm from Maharashtra with rank 1500");
 assert.equal(result.state, 'Maharashtra');
 


### PR DESCRIPTION
## Summary
- improve detection of `JEE Advanced` in `parseCollegeQuery`
- filter out architecture courses in `fetchCollegePredictions`
- add test for `JeeAdvance` phrasing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68416b6e8bc88320b386e6146c853943