### PR TITLE
Support state detection via city keywords

### DIFF
--- a/src/lib/parseCollegeQuery.js
+++ b/src/lib/parseCollegeQuery.js
@@ -74,6 +74,15 @@ export const stateKeywords = {
   lakshadweep: 'Lakshadweep'
 };
 
+export const cityKeywords = {
+  warangal: 'Telangana',
+  trichy: 'Tamil Nadu',
+  kurukshetra: 'Haryana',
+  jaipur: 'Rajasthan',
+  surat: 'Gujarat',
+  gandhinagar: 'Gujarat'
+};
+
 export function parseCollegeQuery(text) {
   const lower = text.toLowerCase();
   let match =
@@ -98,6 +107,12 @@ export function parseCollegeQuery(text) {
   for (const [key, value] of Object.entries(stateKeywords)) {
     const regex = new RegExp(`\\b${key}\\b`, 'i');
     if (regex.test(lower)) { state = value; break; }
+  }
+  if (!state) {
+    for (const [key, value] of Object.entries(cityKeywords)) {
+      const regex = new RegExp(`\\b${key}\\b`, 'i');
+      if (regex.test(lower)) { state = value; break; }
+    }
   }
 
   let examType = null;

--- a/tests/parseCollegeQuery.test.js
+++ b/tests/parseCollegeQuery.test.js
@@ -37,5 +37,23 @@ assert.equal(result.state, 'Maharashtra');
 result = parseCollegeQuery('my state is karnataka');
 assert.equal(result.state, 'Karnataka');
 
+result = parseCollegeQuery('colleges near warangal');
+assert.equal(result.state, 'Telangana');
+
+result = parseCollegeQuery('colleges in trichy');
+assert.equal(result.state, 'Tamil Nadu');
+
+result = parseCollegeQuery('engineering in kurukshetra');
+assert.equal(result.state, 'Haryana');
+
+result = parseCollegeQuery('admission at jaipur');
+assert.equal(result.state, 'Rajasthan');
+
+result = parseCollegeQuery('iit surat campus');
+assert.equal(result.state, 'Gujarat');
+
+result = parseCollegeQuery('rank 1000 gandhinagar institutes');
+assert.equal(result.state, 'Gujarat');
+
 console.log('All tests passed');
 


### PR DESCRIPTION
## Summary
- map cities to states in `parseCollegeQuery`
- detect cities when deriving the `state` value
- test city keywords for correct state mapping

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68416fdfc40c83208873b78122ba67d2