### PR TITLE
Chatbot now links to OS list only

### DIFF
--- a/src/components/Chatbot/ChatInterface.jsx
+++ b/src/components/Chatbot/ChatInterface.jsx
@@ -236,21 +236,6 @@ export default function ChatInterface() {
         if ((parsed.examType || 'JEE Main') === 'JEE Main' && !stateForPrediction) {
           response = { content: currentUiText.askState, relatedContent: null, showHowToUseSuggestion: false };
         } else {
-          const hsColleges = await fetchCollegePredictions(
-            {
-              rank: parsed.rank,
-              examType: parsed.examType || 'JEE Main',
-              category: parsed.category,
-              quota: 'HS',
-              gender: 'Gender-Neutral',
-              isPreparatoryRank: false,
-              state: stateForPrediction
-            },
-            {
-              year: JOSAA_PREDICTION_YEAR,
-              round: JOSAA_PREDICTION_ROUND,
-            }
-          );
           const osColleges = await fetchCollegePredictions(
             {
               rank: parsed.rank,
@@ -266,7 +251,7 @@ export default function ChatInterface() {
               round: JOSAA_PREDICTION_ROUND,
             }
           );
-          const colleges = [...hsColleges, ...osColleges]
+          const colleges = osColleges
             .sort((a, b) => a.closing_rank - b.closing_rank)
             .slice(0, 10);
           if (colleges.length > 0) {


### PR DESCRIPTION
## Summary
- show a single *OS* link in the college suggestion response
- update translations to mention the OS list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68417211026c8320975934f90a66afdd