### PR TITLE
Fix chatbot state reset and adjust college query detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "tailwind:init": "tailwindcss init -p",
-    "test": "node tests/parseCollegeQuery.test.js"
+    "test": "node tests/parseCollegeQuery.test.js && node tests/chatbotReset.test.js"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",

--- a/src/components/Chatbot/ChatInterface.jsx
+++ b/src/components/Chatbot/ChatInterface.jsx
@@ -117,6 +117,13 @@ export default function ChatInterface() {
   const [pendingState, setPendingState] = useState('');
   const [pendingExamType, setPendingExamType] = useState('JEE Main');
 
+  const resetPending = () => {
+    setPendingRank(null);
+    setPendingCategory(null);
+    setPendingState('');
+    setPendingExamType('JEE Main');
+  };
+
   useEffect(() => {
     const langTrans = uiTranslations[language] || uiTranslations.en;
     setCurrentUiText(langTrans);
@@ -238,7 +245,8 @@ export default function ChatInterface() {
     const stateForPrediction = parsed.state || pendingState;
     const examType = parsed.examType || pendingExamType || 'JEE Main';
 
-    const isPotentialCollegeQuery = parsed.isCollegeQuery || pendingRank !== null || pendingCategory !== null || pendingState;
+    const hasAllParams = rank && category && (examType !== 'JEE Main' || stateForPrediction);
+    const isPotentialCollegeQuery = parsed.isCollegeQuery || hasAllParams;
     let response;
     if (isPotentialCollegeQuery) {
       if (!rank || !category) {
@@ -291,9 +299,11 @@ export default function ChatInterface() {
         } else {
           response = { content: currentUiText.fallbackResponse, relatedContent: 'josaa-comprehensive-faq', showHowToUseSuggestion: true };
         }
+        resetPending();
       }
     } else {
       response = await findBestResponse(currentMessageText, language);
+      resetPending();
     }
     const newBotMessage = {
       type: 'bot',

--- a/tests/chatbotReset.test.js
+++ b/tests/chatbotReset.test.js
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { parseCollegeQuery } from '../src/lib/parseCollegeQuery.js';
+
+class DummyChatbot {
+  constructor() {
+    this.reset();
+  }
+  reset() {
+    this.pendingRank = null;
+    this.pendingCategory = null;
+    this.pendingState = '';
+    this.pendingExamType = 'JEE Main';
+  }
+  handle(text) {
+    const parsed = parseCollegeQuery(text);
+    if (parsed.rank !== null) this.pendingRank = parsed.rank;
+    if (parsed.category) this.pendingCategory = parsed.category;
+    if (parsed.state) this.pendingState = parsed.state;
+    if (parsed.examType) this.pendingExamType = parsed.examType;
+
+    const rank = parsed.rank !== null ? parsed.rank : this.pendingRank;
+    const category = parsed.category || this.pendingCategory;
+    const state = parsed.state || this.pendingState;
+    const examType = parsed.examType || this.pendingExamType || 'JEE Main';
+
+    const hasAll = rank && category && (examType !== 'JEE Main' || state);
+    const isPotential = parsed.isCollegeQuery || hasAll;
+    let type;
+    if (isPotential) {
+      if (!hasAll) {
+        type = 'need-info';
+      } else {
+        type = 'prediction';
+        this.reset();
+      }
+    } else {
+      type = 'general';
+      this.reset();
+    }
+    return type;
+  }
+}
+
+let bot = new DummyChatbot();
+let flow = bot.handle('My rank is 1000');
+assert.equal(flow, 'need-info');
+assert.equal(bot.pendingRank, 1000);
+flow = bot.handle('Tell me about documents');
+assert.equal(flow, 'general');
+assert.equal(bot.pendingRank, null);
+assert.equal(bot.pendingCategory, null);
+assert.equal(bot.pendingState, '');
+assert.equal(bot.pendingExamType, 'JEE Main');
+
+bot = new DummyChatbot();
+bot.handle('My rank is 500');
+flow = bot.handle('What college can I get in Karnataka category SC?');
+assert.equal(flow, 'prediction');
+assert.equal(bot.pendingRank, null);
+assert.equal(bot.pendingCategory, null);
+assert.equal(bot.pendingState, '');
+assert.equal(bot.pendingExamType, 'JEE Main');
+
+console.log('Chatbot reset tests passed');


### PR DESCRIPTION
## Summary
- improve college query detection logic and expose pending reset helper
- reset pending college query data after predictions or non-college chat
- add regression tests for reset behaviour
- run `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68417daf0c288320aa308767a16b5a57