### PR TITLE
Improve env var documentation and check Supabase credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,21 @@ the following category keywords are understood (case-insensitive):
 - **SC (PwD)**: `sc pwd`, `sc-pwd`
 - **ST**: `st`
 - **ST (PwD)**: `st pwd`, `st-pwd`
+
+## Environment Variables
+
+Access to college prediction data relies on a Supabase backend. Create a `.env`
+file in the project root and provide the following variables:
+
+```bash
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+VITE_JOSAA_YEAR=2024
+VITE_JOSAA_ROUND=6
+VITE_CSAB_YEAR=2024
+VITE_CSAB_ROUND=2
+```
+
+Replace the placeholders with the values from your Supabase project. Without
+these values the chatbot will respond with a fallback message because it cannot
+fetch prediction data.

--- a/src/lib/fetchCollegePredictions.js
+++ b/src/lib/fetchCollegePredictions.js
@@ -1,5 +1,9 @@
 import { supabase } from './supabase';
 
+const hasSupabaseCreds =
+  Boolean(import.meta.env.VITE_SUPABASE_URL) &&
+  Boolean(import.meta.env.VITE_SUPABASE_ANON_KEY);
+
 export async function fetchCollegePredictions({
   rank,
   examType,
@@ -12,6 +16,12 @@ export async function fetchCollegePredictions({
   const userRankInt = parseInt(rank);
   if (isNaN(userRankInt) || userRankInt <= 0) {
     throw new Error('Invalid rank');
+  }
+
+  if (!hasSupabaseCreds) {
+    throw new Error(
+      'Supabase credentials are missing. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.'
+    );
   }
 
   let query = supabase


### PR DESCRIPTION
## Summary
- document required Supabase and year/round variables in README
- validate Supabase credentials in `fetchCollegePredictions`

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684185276cd083208fbbfebbaf116e8d