### PR TITLE
Remove env vars for prediction year/round

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,10 @@ file in the project root and provide the following variables:
 ```bash
 VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
-VITE_JOSAA_YEAR=2024
-VITE_JOSAA_ROUND=6
-VITE_CSAB_YEAR=2024
-VITE_CSAB_ROUND=2
 ```
 
 Replace the placeholders with the values from your Supabase project. Without
-these values the chatbot will respond with a fallback message because it cannot
-fetch prediction data.
+these credentials the chatbot will respond with a fallback message because it
+cannot fetch prediction data. The JoSAA/CSAB prediction year and round values
+are now hard-coded in `src/config/constants.js` and do not need to be supplied
+via environment variables.

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,4 +1,7 @@
-export const JOSAA_PREDICTION_YEAR = parseInt(import.meta.env.VITE_JOSAA_YEAR) || 2024;
-export const JOSAA_PREDICTION_ROUND = parseInt(import.meta.env.VITE_JOSAA_ROUND) || 6;
-export const CSAB_PREDICTION_YEAR = parseInt(import.meta.env.VITE_CSAB_YEAR) || 2024;
-export const CSAB_PREDICTION_ROUND = parseInt(import.meta.env.VITE_CSAB_ROUND) || 2;
+// Prediction year and round are hard-coded to avoid relying on runtime
+// environment variables. Update these values here whenever the cutoff
+// database changes.
+export const JOSAA_PREDICTION_YEAR = 2024;
+export const JOSAA_PREDICTION_ROUND = 6;
+export const CSAB_PREDICTION_YEAR = 2024;
+export const CSAB_PREDICTION_ROUND = 2;


### PR DESCRIPTION
## Summary
- hard-code JoSAA and CSAB cutoff years/rounds
- update README to note the constants live in `src/config/constants.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418e73e2d0832092f7d6545bd5df3c