### PR TITLE
Handle jee advance queries

### DIFF
--- a/src/lib/parseCollegeQuery.js
+++ b/src/lib/parseCollegeQuery.js
@@ -116,7 +116,7 @@ export function parseCollegeQuery(text) {
   }
 
   let examType = null;
-  if (/\bjee\s*advanced\b/.test(lower) || /\bjee[-\s]?adv\b/.test(lower) || /\bjeeadv(?:ance|anced)?\b/.test(lower)) {
+  if (/\bjee\s*advanced\b/.test(lower) || /\bjee\s*advance\b/.test(lower) || /\bjee[-\s]?adv\b/.test(lower) || /\bjeeadv(?:ance|anced)?\b/.test(lower)) {
     examType = 'JEE Advanced';
   } else if (/\bjee\s*mains?\b/.test(lower) || /\bjee[-\s]?main\b/.test(lower)) {
     examType = 'JEE Main';

--- a/tests/parseCollegeQuery.test.js
+++ b/tests/parseCollegeQuery.test.js
@@ -31,6 +31,9 @@ assert.equal(result.examType, 'JEE Advanced');
 result = parseCollegeQuery('rank 99 in JeeAdvance');
 assert.equal(result.examType, 'JEE Advanced');
 
+result = parseCollegeQuery('rank 500 in jee advance');
+assert.equal(result.examType, 'JEE Advanced');
+
 result = parseCollegeQuery("I'm from Maharashtra with rank 1500");
 assert.equal(result.state, 'Maharashtra');
 


### PR DESCRIPTION
## Summary
- recognise `jee advance` as the JEE Advanced exam
- cover `jee advance` detection in parser tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684197240e1c832098086d97d7728cf3