### PR TITLE
Guard console logs in pages

### DIFF
--- a/src/pages/AboutUsPage.jsx
+++ b/src/pages/AboutUsPage.jsx
@@ -19,13 +19,19 @@ export default function AboutUsPage() {
 
   useEffect(() => {
     const fetchContent = async () => {
-      console.log(`AboutUsPage: useEffect triggered. Current language from context: ${language}`);
+      if (import.meta.env.DEV) {
+        console.log(`AboutUsPage: useEffect triggered. Current language from context: ${language}`);
+      }
       setLoading(true);
       setError(null);
       setContent(null);
       let currentLangToFetch = language;
       setDisplayLanguage(language);
-      console.log(`AboutUsPage: Attempting to fetch content from 'static_page_content' for page_identifier: '${PAGE_IDENTIFIER}', language_code: '${currentLangToFetch}'`);
+      if (import.meta.env.DEV) {
+        console.log(
+          `AboutUsPage: Attempting to fetch content from 'static_page_content' for page_identifier: '${PAGE_IDENTIFIER}', language_code: '${currentLangToFetch}'`
+        );
+      }
 
       try {
         let { data, error: supabaseError } = await supabase
@@ -35,10 +41,19 @@ export default function AboutUsPage() {
           .eq('language_code', currentLangToFetch)
           .single();
 
-        console.log(`AboutUsPage: Initial fetch for '${currentLangToFetch}' - Data:`, data, `SupabaseError:`, supabaseError);
+        if (import.meta.env.DEV) {
+          console.log(
+            `AboutUsPage: Initial fetch for '${currentLangToFetch}' - Data:`,
+            data,
+            `SupabaseError:`,
+            supabaseError
+          );
+        }
 
         if (supabaseError || !data) {
-          console.log(`AboutUsPage: Initial fetch failed or no data. SupabaseError: ${supabaseError?.message}, Data: ${data}`);
+          if (import.meta.env.DEV) {
+            console.log(`AboutUsPage: Initial fetch failed or no data. SupabaseError: ${supabaseError?.message}, Data: ${data}`);
+          }
           if (currentLangToFetch !== 'en') {
             console.warn(`AboutUsPage: Content in '${currentLangToFetch}' not found or error occurred. Trying English fallback for 'static_page_content'.`);
             
@@ -49,7 +64,14 @@ export default function AboutUsPage() {
               .eq('language_code', 'en')
               .single();
             
-            console.log(`AboutUsPage: English fallback fetch from 'static_page_content' - FallbackData:`, fallbackData, `FallbackError:`, fallbackError);
+            if (import.meta.env.DEV) {
+              console.log(
+                `AboutUsPage: English fallback fetch from 'static_page_content' - FallbackData:`,
+                fallbackData,
+                `FallbackError:`,
+                fallbackError
+              );
+            }
 
             if (fallbackError || !fallbackData) {
               const mainErrorMsg = fallbackError?.message || `About Us page content (from static_page_content) not found in English either for identifier '${PAGE_IDENTIFIER}'.`;
@@ -58,7 +80,9 @@ export default function AboutUsPage() {
             }
             setContent(fallbackData);
             setDisplayLanguage('en');
-            console.log(`AboutUsPage: Successfully set content from English fallback (static_page_content).`);
+            if (import.meta.env.DEV) {
+              console.log(`AboutUsPage: Successfully set content from English fallback (static_page_content).`);
+            }
           } else {
             const mainErrorMsg = supabaseError?.message || `About Us page content (from static_page_content) not found for ${currentLangToFetch} and identifier '${PAGE_IDENTIFIER}'.`;
             console.error(`AboutUsPage: Error fetching English content or no data and no fallback (static_page_content). Error: ${mainErrorMsg}`);
@@ -67,21 +91,31 @@ export default function AboutUsPage() {
         } else {
           setContent(data);
           setDisplayLanguage(data.language_code);
-          console.log(`AboutUsPage: Successfully set content from 'static_page_content' for language: ${data.language_code}`);
+          if (import.meta.env.DEV) {
+            console.log(`AboutUsPage: Successfully set content from 'static_page_content' for language: ${data.language_code}`);
+          }
         }
       } catch (err) {
         console.error(`AboutUsPage: Error caught in fetchContent (static_page_content) - Message: ${err.message}`, err);
         setError(err.message);
       } finally {
         setLoading(false);
-        console.log(`AboutUsPage: fetchContent (static_page_content) finished. Loading: false.`);
+        if (import.meta.env.DEV) {
+          console.log(`AboutUsPage: fetchContent (static_page_content) finished. Loading: false.`);
+        }
       }
     };
 
     fetchContent();
   }, [language]);
 
-  console.log(`AboutUsPage: Rendering component - Loading: ${loading}, Error: ${error}, Content:`, content, `DisplayLanguage: ${displayLanguage}`);
+  if (import.meta.env.DEV) {
+    console.log(
+      `AboutUsPage: Rendering component - Loading: ${loading}, Error: ${error}, Content:`,
+      content,
+      `DisplayLanguage: ${displayLanguage}`
+    );
+  }
 
   if (loading) {
     return (

--- a/src/pages/ContentPage.jsx
+++ b/src/pages/ContentPage.jsx
@@ -19,7 +19,9 @@ export default function ContentPage() {
 
   useEffect(() => {
     const fetchContent = async () => {
-      console.log(`ContentPage: useEffect triggered for slug: '${slug}', language from context: '${language}'`);
+      if (import.meta.env.DEV) {
+        console.log(`ContentPage: useEffect triggered for slug: '${slug}', language from context: '${language}'`);
+      }
       if (!slug) {
         setError('Page slug is missing.');
         setLoading(false);
@@ -32,7 +34,11 @@ export default function ContentPage() {
       setPageData(null);
       let currentLangToFetch = language;
       setDisplayLanguage(language);
-      console.log(`ContentPage: Attempting to fetch content for slug: '${slug}', language: '${currentLangToFetch}' from 'content_pages' table.`);
+      if (import.meta.env.DEV) {
+        console.log(
+          `ContentPage: Attempting to fetch content for slug: '${slug}', language: '${currentLangToFetch}' from 'content_pages' table.`
+        );
+      }
 
       try {
         let { data, error: supabaseError } = await supabase
@@ -41,7 +47,14 @@ export default function ContentPage() {
           .eq('slug', slug)
           .eq('language', currentLangToFetch);
 
-        console.log(`ContentPage: Initial fetch for '${currentLangToFetch}' - SupabaseError:`, supabaseError, `Data:`, data);
+        if (import.meta.env.DEV) {
+          console.log(
+            `ContentPage: Initial fetch for '${currentLangToFetch}' - SupabaseError:`,
+            supabaseError,
+            `Data:`,
+            data
+          );
+        }
 
         let foundContent = null;
 
@@ -49,7 +62,9 @@ export default function ContentPage() {
           console.error(`ContentPage: Supabase error on initial fetch for '${currentLangToFetch}':`, supabaseError.message);
         } else if (data && data.length === 1) {
           foundContent = data[0];
-          console.log(`ContentPage: Found one entry for slug '${slug}' in '${currentLangToFetch}'.`);
+          if (import.meta.env.DEV) {
+            console.log(`ContentPage: Found one entry for slug '${slug}' in '${currentLangToFetch}'.`);
+          }
         } else if (data && data.length > 1) {
           console.warn(`ContentPage: Found multiple entries (${data.length}) for slug '${slug}' in '${currentLangToFetch}'. Using the first one.`);
           foundContent = data[0]; 
@@ -64,7 +79,14 @@ export default function ContentPage() {
             .eq('slug', slug)
             .eq('language', 'en');
 
-          console.log(`ContentPage: English fallback fetch from 'content_pages' - FallbackError:`, fallbackError, `FallbackData:`, fallbackData);
+          if (import.meta.env.DEV) {
+            console.log(
+              `ContentPage: English fallback fetch from 'content_pages' - FallbackError:`,
+              fallbackError,
+              `FallbackData:`,
+              fallbackData
+            );
+          }
 
           if (fallbackError) {
             console.error(`ContentPage: Supabase error on English fallback fetch:`, fallbackError.message);
@@ -72,7 +94,9 @@ export default function ContentPage() {
           } else if (fallbackData && fallbackData.length === 1) {
             foundContent = fallbackData[0];
             setDisplayLanguage('en');
-            console.log(`ContentPage: Found one entry for slug '${slug}' in English (fallback from content_pages).`);
+            if (import.meta.env.DEV) {
+              console.log(`ContentPage: Found one entry for slug '${slug}' in English (fallback from content_pages).`);
+            }
           } else if (fallbackData && fallbackData.length > 1) {
             console.warn(`ContentPage: Found multiple entries (${fallbackData.length}) for slug '${slug}' in English (fallback from content_pages). Using the first one.`);
             foundContent = fallbackData[0];
@@ -87,7 +111,9 @@ export default function ContentPage() {
         if (foundContent) {
           setPageData(foundContent);
           setDisplayLanguage(foundContent.language);
-          console.log(`ContentPage: Successfully set pageData for language: ${foundContent.language}`);
+          if (import.meta.env.DEV) {
+            console.log(`ContentPage: Successfully set pageData for language: ${foundContent.language}`);
+          }
         } else if (!supabaseError) { 
           throw new Error(`Page "${slug}" content could not be loaded for language '${currentLangToFetch}' (from content_pages).`);
         }
@@ -97,14 +123,21 @@ export default function ContentPage() {
         setError(err.message);
       } finally {
         setLoading(false);
-        console.log(`ContentPage: fetchContent (content_pages) finished. Loading: false.`);
+        if (import.meta.env.DEV) {
+          console.log(`ContentPage: fetchContent (content_pages) finished. Loading: false.`);
+        }
       }
     };
 
     fetchContent();
   }, [slug, language]);
 
-  console.log(`ContentPage: Rendering component - Slug: ${slug}, Loading: ${loading}, Error: ${error}, PageData:`, pageData);
+  if (import.meta.env.DEV) {
+    console.log(
+      `ContentPage: Rendering component - Slug: ${slug}, Loading: ${loading}, Error: ${error}, PageData:`,
+      pageData
+    );
+  }
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- wrap console.log statements with `import.meta.env.DEV` guards in ContentPage and AboutUsPage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a2c736c88320adb22f86167b1afe