### PR TITLE
Fix missing semicolon in Supabase client

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,6 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey) 
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add semicolon to exported `createClient` call in `supabase.js`
- ensure `supabase.js` has a trailing newline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a60886648320ba551fb65de9b638