### PR TITLE
Remove leftover console logs from tests

### DIFF
--- a/tests/chatbotReset.test.js
+++ b/tests/chatbotReset.test.js
@@ -61,4 +61,3 @@ assert.equal(bot.pendingCategory, null);
 assert.equal(bot.pendingState, '');
 assert.equal(bot.pendingExamType, 'JEE Main');
 
-console.log('Chatbot reset tests passed');

--- a/tests/parseCollegeQuery.test.js
+++ b/tests/parseCollegeQuery.test.js
@@ -58,5 +58,4 @@ assert.equal(result.state, 'Gujarat');
 result = parseCollegeQuery('rank 1000 gandhinagar institutes');
 assert.equal(result.state, 'Gujarat');
 
-console.log('All tests passed');
 


### PR DESCRIPTION
## Summary
- tidy test files by removing leftover `console.log` statements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c1dceaac83208e249ceaf158eca0