### PR TITLE
feat: refresh UI theme with new colors and fonts

### DIFF
--- a/src/components/Layout/Footer.jsx
+++ b/src/components/Layout/Footer.jsx
@@ -3,21 +3,21 @@ import { Link } from 'react-router-dom'; // Import Link
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-100 border-t border-gray-200 mt-12"> {/* Slightly different bg and border, added mt-12 for more space */}
-      <div className="container mx-auto px-4 py-8"> {/* Increased padding */}
-        <div className="text-center text-gray-700">
+    <footer className="bg-gradient-to-r from-primary to-accent-alt text-white mt-12">
+      <div className="container mx-auto px-4 py-8">
+        <div className="text-center">
           <p className="font-semibold text-lg mb-2">Guruvela</p>
           <p className="text-sm mb-4">
             Your trusted guide for JOSAA, CSAB, and all things related to engineering admissions in India.
           </p>
           <div className="flex justify-center space-x-4 mb-4 text-sm">
-            <Link to="/about-us" className="text-gray-600 hover:text-primary transition-colors">About Us</Link>
-            <Link to="/faqs" className="text-gray-600 hover:text-primary transition-colors">FAQ & Guides</Link>
+            <Link to="/about-us" className="text-white/80 hover:text-white transition-colors">About Us</Link>
+            <Link to="/faqs" className="text-white/80 hover:text-white transition-colors">FAQ & Guides</Link>
             {/* Placeholder Links - replace '#' with actual paths when ready */}
-            <Link to="#" className="text-gray-600 hover:text-primary transition-colors">Privacy Policy</Link>
-            <Link to="#" className="text-gray-600 hover:text-primary transition-colors">Terms of Service</Link>
+            <Link to="#" className="text-white/80 hover:text-white transition-colors">Privacy Policy</Link>
+            <Link to="#" className="text-white/80 hover:text-white transition-colors">Terms of Service</Link>
           </div>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-white/60">
             © {new Date().getFullYear()} Guruvela. All rights reserved.
           </p>
         </div>

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -68,12 +68,12 @@ export default function Header() {
   };
 
   return (
-    <header className="bg-white shadow-sm sticky top-0 z-50">
+    <header className="bg-gradient-to-r from-primary to-accent-alt text-white shadow-md sticky top-0 z-50">
       <nav className="container mx-auto px-4 py-4" aria-label="Main navigation">
         <div className="flex items-center justify-between">
-          <Link 
-            to="/" 
-            className="text-2xl font-bold text-primary hover:text-blue-600 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-primary/50 rounded-lg" 
+          <Link
+            to="/"
+            className="text-2xl font-bold text-white hover:text-accent-alt transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-white/50 rounded-lg"
             onClick={closeAllDropdowns} // Close all if home is clicked
             aria-label="Guruvela Home"
           >
@@ -85,7 +85,7 @@ export default function Header() {
             <button
               type="button"
               onClick={toggleMobileMenu} // Use the specific toggle function
-              className="p-2 text-gray-600 hover:text-primary hover:bg-gray-100 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/50 transition-colors duration-150"
+              className="p-2 text-white hover:text-accent-alt hover:bg-white/10 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 transition-colors duration-150"
               aria-label={isMobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
               aria-expanded={isMobileMenuOpen}
               aria-controls="mobile-menu-panel" // Ensure this matches the id of the panel
@@ -101,14 +101,14 @@ export default function Header() {
           </div>
 
           {/* Navigation Links Panel (Mobile Menu Panel) */}
-          <div 
+          <div
             id="mobile-menu-panel" // Added ID for aria-controls
             ref={mobileMenuRef}  // Assign ref to the panel itself
             className={`
-              absolute top-full left-0 w-full bg-white shadow-lg md:shadow-none 
-              md:static md:w-auto md:flex md:items-center md:space-x-1 lg:space-x-3 
+              absolute top-full left-0 w-full bg-gradient-to-b from-primary to-accent-alt shadow-lg md:shadow-none
+              md:static md:w-auto md:flex md:items-center md:space-x-1 lg:space-x-3
               ${isMobileMenuOpen ? 'block' : 'hidden'}
-              transition-all duration-300 ease-in-out z-40 
+              transition-all duration-300 ease-in-out z-40
               md:p-0
             `}
           >
@@ -119,8 +119,8 @@ export default function Header() {
                   type="button"
                   onClick={() => setIsPredictorDropdownOpen(prev => !prev)}
                   className={`w-full text-left md:text-center py-2 px-1 md:px-2 rounded-lg flex items-center justify-between md:justify-start transition-colors duration-150
-                    ${isPredictorDropdownOpen ? 'text-primary bg-gray-50' : 'text-gray-600 hover:text-primary hover:bg-gray-50'}
-                    focus:outline-none focus:ring-2 focus:ring-primary/50`}
+                    ${isPredictorDropdownOpen ? 'text-accent bg-white/10' : 'text-white hover:text-accent hover:bg-white/10'}
+                    focus:outline-none focus:ring-2 focus:ring-white/50`}
                   aria-expanded={isPredictorDropdownOpen}
                   aria-controls="predictor-dropdown"
                 >
@@ -159,8 +159,8 @@ export default function Header() {
                   type="button"
                   onClick={() => setIsDocumentsDropdownOpen(prev => !prev)}
                   className={`w-full text-left md:text-center py-2 px-1 md:px-2 rounded-lg flex items-center justify-between md:justify-start transition-colors duration-150
-                    ${isDocumentsDropdownOpen ? 'text-primary bg-gray-50' : 'text-gray-600 hover:text-primary hover:bg-gray-50'}
-                    focus:outline-none focus:ring-2 focus:ring-primary/50`}
+                    ${isDocumentsDropdownOpen ? 'text-accent bg-white/10' : 'text-white hover:text-accent hover:bg-white/10'}
+                    focus:outline-none focus:ring-2 focus:ring-white/50`}
                   aria-expanded={isDocumentsDropdownOpen}
                   aria-controls="documents-dropdown"
                 >
@@ -197,7 +197,7 @@ export default function Header() {
 
               <Link 
                 to="/preference-guides"
-                className={`nav-link py-2 px-1 md:px-2 rounded-lg block transition-colors duration-150 ${isActive('/preference-guides') ? 'nav-link-active bg-gray-50' : ''}`}
+                className={`nav-link py-2 px-1 md:px-2 rounded-lg block transition-colors duration-150 ${isActive('/preference-guides') ? 'nav-link-active bg-white/10' : ''}`}
                 onClick={closeAllDropdowns} // Close all
               >
                 Preference Guides
@@ -205,28 +205,28 @@ export default function Header() {
 
               <Link 
                 to="/mentors" 
-                className={`nav-link py-2 px-1 md:px-2 rounded-lg block transition-colors duration-150 ${isActive('/mentors') ? 'nav-link-active bg-gray-50' : ''}`}
+                className={`nav-link py-2 px-1 md:px-2 rounded-lg block transition-colors duration-150 ${isActive('/mentors') ? 'nav-link-active bg-white/10' : ''}`}
                 onClick={closeAllDropdowns} // Close all
               >
                 Mentors
               </Link>
               <Link 
                 to="/about-us" 
-                className={`nav-link py-2 px-1 md:px-2 rounded-lg block transition-colors duration-150 ${isActive('/about-us') ? 'nav-link-active bg-gray-50' : ''}`}
+                className={`nav-link py-2 px-1 md:px-2 rounded-lg block transition-colors duration-150 ${isActive('/about-us') ? 'nav-link-active bg-white/10' : ''}`}
                 onClick={closeAllDropdowns} // Close all
               >
                 About
               </Link>
               <Link 
                 to="/how-to-use" 
-                className={`nav-link py-2 px-1 md:px-2 rounded-lg block transition-colors duration-150 ${isActive('/how-to-use') ? 'nav-link-active bg-gray-50' : ''}`}
+                className={`nav-link py-2 px-1 md:px-2 rounded-lg block transition-colors duration-150 ${isActive('/how-to-use') ? 'nav-link-active bg-white/10' : ''}`}
                 onClick={closeAllDropdowns} // Close all
               >
                 How to Use
               </Link>
               <Link 
                 to="/faqs" 
-                className={`nav-link py-2 px-1 md:px-2 rounded-lg block transition-colors duration-150 ${isActive('/faqs') ? 'nav-link-active bg-gray-50' : ''}`}
+                className={`nav-link py-2 px-1 md:px-2 rounded-lg block transition-colors duration-150 ${isActive('/faqs') ? 'nav-link-active bg-white/10' : ''}`}
                 onClick={closeAllDropdowns} // Close all
               >
                 FAQ & Guides
@@ -238,8 +238,8 @@ export default function Header() {
                   type="button"
                   onClick={() => setIsLangDropdownOpen(prev => !prev)}
                   className={`w-full text-left md:text-center py-2 px-1 md:px-2 rounded-lg flex items-center justify-between md:justify-start transition-colors duration-150
-                    ${isLangDropdownOpen ? 'text-primary bg-gray-50' : 'text-gray-600 hover:text-primary hover:bg-gray-50'}
-                    focus:outline-none focus:ring-2 focus:ring-primary/50`}
+                    ${isLangDropdownOpen ? 'text-accent bg-white/10' : 'text-white hover:text-accent hover:bg-white/10'}
+                    focus:outline-none focus:ring-2 focus:ring-white/50`}
                   aria-expanded={isLangDropdownOpen}
                   aria-controls="language-dropdown"
                 >

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -6,7 +6,7 @@
 
 @layer base {
   body {
-    @apply bg-gray-50 text-gray-800 font-sans antialiased;
+    @apply bg-gradient-to-br from-primary/10 via-white to-accent/10 text-gray-800 font-sans antialiased;
   }
 
   h1, h2, h3, h4, h5, h6 {
@@ -23,13 +23,13 @@
   }
 
   .btn-primary {
-    @apply btn bg-primary text-white hover:bg-blue-700
-           focus:ring-primary/50 active:bg-blue-800;
+    @apply btn bg-primary text-white hover:bg-purple-700
+           focus:ring-primary/50 active:bg-purple-800;
   }
 
   .btn-accent {
-    @apply btn bg-accent text-white hover:bg-orange-800
-           focus:ring-accent/50 active:bg-orange-900;
+    @apply btn bg-accent text-white hover:bg-amber-600
+           focus:ring-accent/50 active:bg-amber-700;
   }
 
   .btn-outline {
@@ -60,11 +60,11 @@
 
   /* Navigation */
   .nav-link {
-    @apply text-gray-600 hover:text-primary transition-colors;
+    @apply text-white hover:text-accent transition-colors;
   }
 
   .nav-link-active {
-    @apply text-primary font-medium;
+    @apply text-accent font-medium;
   }
 
   /* Chat Interface */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,12 +8,12 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: '#2563EB',    // blue-600
-        accent: '#C2410C',     // orange-700
-        'accent-alt': '#10B981', // emerald-500
+        primary: '#7C3AED',    // purple-600
+        accent: '#F59E0B',     // amber-500
+        'accent-alt': '#EC4899', // pink-500
       },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        sans: ['Poppins', 'Inter', 'system-ui', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- adopt purple/amber/pink palette and Poppins typography
- apply gradient backgrounds to header and footer
- update navigation and buttons for new theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3224dc5148331b46b24dccedf3bad