### PR TITLE
Use regex for category keywords

### DIFF
--- a/src/lib/parseCollegeQuery.js
+++ b/src/lib/parseCollegeQuery.js
@@ -32,6 +32,13 @@ export const categoryMap = {
   open: 'OPEN'
 };
 
+const categoryRegexMap = new Map(
+  Object.entries(categoryMap).map(([key, value]) => {
+    const escaped = key.replace(/[-\\*+?.()|[\]{}]/g, '\\$&');
+    return [new RegExp(`\\b${escaped}\\b`, 'i'), value];
+  })
+);
+
 export const stateKeywords = {
   'andhra pradesh': 'Andhra Pradesh',
   'arunachal pradesh': 'Arunachal Pradesh',
@@ -95,8 +102,8 @@ export function parseCollegeQuery(text) {
   const rank = rankStr ? parseInt(rankStr, 10) : null;
 
   let category = null;
-  for (const [key, value] of Object.entries(categoryMap)) {
-    if (lower.includes(key.toLowerCase())) { category = value; break; }
+  for (const [regex, value] of categoryRegexMap) {
+    if (regex.test(lower)) { category = value; break; }
   }
   const branchMatch = text.match(/\b(CSE|Computer Science|ECE|Electrical|Electronics|Mechanical|Civil|IT|Information Technology)\b/i);
   const branch = branchMatch ? branchMatch[0] : null;

--- a/tests/parseCollegeQuery.test.js
+++ b/tests/parseCollegeQuery.test.js
@@ -59,3 +59,10 @@ result = parseCollegeQuery('rank 1000 gandhinagar institutes');
 assert.equal(result.state, 'Gujarat');
 
 
+result = parseCollegeQuery('I love science');
+assert.equal(result.category, null);
+
+result = parseCollegeQuery('scam details');
+assert.equal(result.category, null);
+
+


### PR DESCRIPTION
## Summary
- precompile regex map for category keywords and use \b-boundary matches
- add tests to ensure unrelated words like "science" or "scam" don't trigger categories

## Testing
- `npm test`
- `npm run lint` *(fails: 'Component' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b33542ae748331875008010d6b3aa8