### PR TITLE
Fix rank predictor probability logic and export button

### DIFF
--- a/src/lib/fetchCollegePredictions.js
+++ b/src/lib/fetchCollegePredictions.js
@@ -45,7 +45,13 @@ export async function fetchCollegePredictions({
   }
 
   query = query.eq('is_preparatory', isPreparatoryRank);
-  query = query.gte('closing_rank', userRankInt);
+
+  // To allow for "reach" colleges (Low/Medium probability), we include colleges
+  // where the closing rank is up to 500 ranks better than the user's rank.
+  const minClosingRank = Math.max(1, userRankInt - 500);
+  query = query.gte('closing_rank', minClosingRank);
+
+  // Order by closing rank to get colleges starting from the most ambitious
   query = query.order('closing_rank', { ascending: true }).limit(100);
 
   const { data, error } = await query;
@@ -53,6 +59,28 @@ export async function fetchCollegePredictions({
     throw error;
   }
 
-  const filtered = (data || []).filter(item => !/architecture/i.test(item.branch_name));
+  const filtered = (data || []).filter(item => !/architecture/i.test(item.branch_name)).map(item => {
+    const diff = item.closing_rank - userRankInt;
+    let probability;
+
+    // High probability: User rank is better by 200 or more
+    if (diff >= 200) {
+      probability = 95;
+    }
+    // Medium probability: User rank is close (between -50 and 200)
+    else if (diff >= -50 && diff < 200) {
+      probability = 75;
+    }
+    // Low probability: User rank is worse by more than 50
+    else {
+      probability = 30;
+    }
+
+    return {
+      ...item,
+      probability
+    };
+  });
+
   return filtered;
 }

--- a/src/pages/RankPredictorPage.jsx
+++ b/src/pages/RankPredictorPage.jsx
@@ -255,7 +255,9 @@ export default function RankPredictorPage() {
                       className="px-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 w-full sm:w-64"
                     />
                     <button onClick={handleExport} className="px-4 py-2 border border-gray-200 rounded-lg text-sm font-semibold text-gray-700 hover:bg-gray-50 flex items-center gap-2 whitespace-nowrap">
-                  </button>
+                      <Download className="w-4 h-4" />
+                      Download
+                    </button>
                 </div>
               </div>
 
@@ -298,7 +300,7 @@ export default function RankPredictorPage() {
                     </thead>
                     <tbody className="divide-y divide-gray-100">
                       {filteredResults.slice(0, visibleCount).map((result, idx) => {
-                        const prob = getProbabilityLabel(result.probability || Math.floor(Math.random() * 100)); // fallback if probability missing
+                        const prob = getProbabilityLabel(result.probability || 0); // Use 0 as fallback if missing
                         return (
                           <tr key={idx} className="hover:bg-blue-50/30 transition-colors">
                             <td className="px-6 py-5">


### PR DESCRIPTION
- Modifies `fetchCollegePredictions` to fetch colleges where the `closing_rank` is up to 500 ranks higher than the user's rank to accommodate "reach" colleges.
- Implements correct probability mapping (High > 95%, Medium 75%, Low 30%) based on user rank vs previous closing rank.
- Adds text "Download" and an icon to the export button to make it visible and actionable.
- Replaces `Math.random` fallback for probability with a robust default of 0.

---
*PR created automatically by Jules for task [16405569976499786532](https://jules.google.com/task/16405569976499786532) started by @06Gagan*